### PR TITLE
Assembler offsets

### DIFF
--- a/DesktopEmulator/ConsoleLogic/V32GPU.cpp
+++ b/DesktopEmulator/ConsoleLogic/V32GPU.cpp
@@ -375,7 +375,7 @@ namespace V32
         RegionQuad.Vertices[ 3 ].texture_y = TextureMaxY;
         
         // precalculate angle properties when needed
-        float AngleCos, AngleSin;
+        float AngleCos = 0.0, AngleSin = 0.0;
         
         if( RotationEnabled )
         {

--- a/DesktopEmulator/ControlsEditor/GUI.cpp
+++ b/DesktopEmulator/ControlsEditor/GUI.cpp
@@ -660,7 +660,7 @@ void RenderGUI()
         ImGui::Separator();
         
         ImGui::SetCursorScreenPos(ImVec2(19,163));
-        ImGui::Image( (void*)GamepadTextureID, ImVec2(1024,256) );
+        ImGui::Image( (ImTextureID)(intptr_t)GamepadTextureID, ImVec2(1024,256) );
         
         // now write the actual values
         if( SelectedProfile )

--- a/DesktopEmulator/ControlsEditor/Globals.cpp
+++ b/DesktopEmulator/ControlsEditor/Globals.cpp
@@ -34,4 +34,4 @@ OpenGL2DContext OpenGL2D;
 
 // resources
 char ProfileName[ 41 ];
-unsigned GamepadTextureID;
+GLuint GamepadTextureID;

--- a/DesktopEmulator/ControlsEditor/Globals.hpp
+++ b/DesktopEmulator/ControlsEditor/Globals.hpp
@@ -34,7 +34,7 @@ extern OpenGL2DContext OpenGL2D;
 
 
 extern char ProfileName[ 41 ];
-extern unsigned GamepadTextureID;
+extern GLuint GamepadTextureID;
 
 
 // *****************************************************************************

--- a/DevelopmentTools/Assembler/DebugInfo.cpp
+++ b/DevelopmentTools/Assembler/DebugInfo.cpp
@@ -42,26 +42,32 @@ string NormalizePath( const string& Path )
 // =============================================================================
 
 
-void SaveDebugInfoFile( const string& FilePath, const VirconASMParser& Parser, const VirconASMEmitter& Emitter )
+void SaveDebugInfoFile
+(
+    const std::string& FilePath,
+    const VirconASMParser& Parser,
+    const VirconASMEmitter& Emitter,
+    DebugInfoModes Mode
+)
 {
     if( VerboseMode )
       cout << "saving debug info file" << endl;
-
-	int BaseOffset  = 0;
-	int UnitSize    = 1;
-
-	if( CartridgeOffset )
-	{
-		BaseOffset  = 0x8C;
-		UnitSize    = 4;
-	}
     
-	if( VBINOffset )
-	{
-		BaseOffset  = 0x0C;
-		UnitSize    = 4;
-	}
-
+    int BaseOffset  = 0;   // initial address for the first byte/word
+    int UnitSize    = 1;   // word subdivision (1 = full words, 4 = individual bytes)
+    
+    if( Mode == DebugInfoModes::V32File )
+    {
+        BaseOffset  = 0x8C;
+        UnitSize    = 4;
+    }
+    
+    if( Mode == DebugInfoModes::VBINFile )
+    {
+        BaseOffset  = 0x0C;
+        UnitSize    = 4;
+    }
+    
     // open output file,
     ofstream DebugInfoFile;
     OpenOutputFile( DebugInfoFile, FilePath );
@@ -76,8 +82,8 @@ void SaveDebugInfoFile( const string& FilePath, const VirconASMParser& Parser, c
         if( Node->Type() != ASTNodeTypes::Instruction )
           continue;
         
-
-        DebugInfoFile << Hex( Node->AddressInROM * UnitSize + BaseOffset, 8 );
+        
+        DebugInfoFile << Hex( BaseOffset + Node->AddressInROM * UnitSize, 8 );
         DebugInfoFile << "," << NormalizePath( Node->Location.FilePath );
         DebugInfoFile << "," << Node->Location.Line;
         

--- a/DevelopmentTools/Assembler/DebugInfo.cpp
+++ b/DevelopmentTools/Assembler/DebugInfo.cpp
@@ -46,7 +46,22 @@ void SaveDebugInfoFile( const string& FilePath, const VirconASMParser& Parser, c
 {
     if( VerboseMode )
       cout << "saving debug info file" << endl;
+
+	int BaseOffset  = 0;
+	int UnitSize    = 1;
+
+	if( CartridgeOffset )
+	{
+		BaseOffset  = 0x8C;
+		UnitSize    = 4;
+	}
     
+	if( VBINOffset )
+	{
+		BaseOffset  = 0x0C;
+		UnitSize    = 4;
+	}
+
     // open output file,
     ofstream DebugInfoFile;
     OpenOutputFile( DebugInfoFile, FilePath );
@@ -61,7 +76,8 @@ void SaveDebugInfoFile( const string& FilePath, const VirconASMParser& Parser, c
         if( Node->Type() != ASTNodeTypes::Instruction )
           continue;
         
-        DebugInfoFile << Hex( Node->AddressInROM, 8 );
+
+        DebugInfoFile << Hex( Node->AddressInROM * UnitSize + BaseOffset, 8 );
         DebugInfoFile << "," << NormalizePath( Node->Location.FilePath );
         DebugInfoFile << "," << Node->Location.Line;
         

--- a/DevelopmentTools/Assembler/DebugInfo.hpp
+++ b/DevelopmentTools/Assembler/DebugInfo.hpp
@@ -11,8 +11,22 @@
 // =============================================================================
 
 
+// address reference modes for debug info
+enum class DebugInfoModes
+{
+    Program,     // addresses in words, relative to program start
+    VBINFile,    // addresses in bytes, relative to assembled VBIN file
+    V32File      // addresses in bytes, relative to final V32 rom file
+};
+
 // save debug info for the program
-void SaveDebugInfoFile( const std::string& FilePath, const VirconASMParser& Parser, const VirconASMEmitter& Emitter );
+void SaveDebugInfoFile
+(
+    const std::string& FilePath,
+    const VirconASMParser& Parser,
+    const VirconASMEmitter& Emitter,
+    DebugInfoModes Mode
+);
 
 // save debug logs for the internal stages of the assembler itself
 void SaveLexerLog( const std::string& FilePath, const VirconASMPreprocessor& Preprocessor );

--- a/DevelopmentTools/Assembler/Globals.cpp
+++ b/DevelopmentTools/Assembler/Globals.cpp
@@ -24,3 +24,5 @@ bool VerboseMode = false;
 string AssemblerFolder;
 int InitialROMAddress = Constants::CartridgeProgramROMFirstAddress;
 bool CreateDebugVersion = false;
+bool CartridgeOffset = false;
+bool VBINOffset = false;

--- a/DevelopmentTools/Assembler/Globals.cpp
+++ b/DevelopmentTools/Assembler/Globals.cpp
@@ -24,5 +24,3 @@ bool VerboseMode = false;
 string AssemblerFolder;
 int InitialROMAddress = Constants::CartridgeProgramROMFirstAddress;
 bool CreateDebugVersion = false;
-bool CartridgeOffset = false;
-bool VBINOffset = false;

--- a/DevelopmentTools/Assembler/Globals.hpp
+++ b/DevelopmentTools/Assembler/Globals.hpp
@@ -21,6 +21,8 @@ extern bool VerboseMode;
 extern std::string AssemblerFolder;
 extern int InitialROMAddress;
 extern bool CreateDebugVersion;
+extern bool CartridgeOffset;
+extern bool VBINOffset;
 
 
 // *****************************************************************************

--- a/DevelopmentTools/Assembler/Globals.hpp
+++ b/DevelopmentTools/Assembler/Globals.hpp
@@ -21,8 +21,6 @@ extern bool VerboseMode;
 extern std::string AssemblerFolder;
 extern int InitialROMAddress;
 extern bool CreateDebugVersion;
-extern bool CartridgeOffset;
-extern bool VBINOffset;
 
 
 // *****************************************************************************

--- a/DevelopmentTools/Assembler/Main.cpp
+++ b/DevelopmentTools/Assembler/Main.cpp
@@ -51,8 +51,10 @@ void PrintUsage()
     cout << "  --debugmode  Creates files with results of internal stages" << endl;
     cout << "  -o <file>    Output file, default name is the same as input" << endl;
     cout << "  -b           Assembles the code as a BIOS" << endl;
-    cout << "  -v           Displays additional information (verbose)" << endl;
     cout << "  -g           Outputs an additional file with debug info" << endl;
+    cout << "  --cartoffset Used with '-g': full cart offsets in bytes" << endl;
+    cout << "  --vbinoffset Used with '-g': VBIN section offsets in bytes" << endl;
+    cout << "  -v           Displays additional information (verbose)" << endl;
     cout << "Also, the following options are accepted for compatibility" << endl;
     cout << "but have no effect: -s" << endl;
 }
@@ -155,6 +157,18 @@ int main( int NumberOfArguments, char* Arguments[] )
             if( ArgumentsUTF8[i] == string("-g") )
             {
                 CreateDebugVersion = true;
+                continue;
+            }
+            
+            if( ArgumentsUTF8[i] == string("--cartoffset") )
+            {
+                CartridgeOffset = true;
+                continue;
+            }
+            
+            if( ArgumentsUTF8[i] == string("--vbinoffset") )
+            {
+                VBINOffset = true;
                 continue;
             }
             

--- a/DevelopmentTools/Assembler/Main.cpp
+++ b/DevelopmentTools/Assembler/Main.cpp
@@ -51,13 +51,16 @@ void PrintUsage()
     cout << "  --debugmode  Creates files with results of internal stages" << endl;
     cout << "  -o <file>    Output file, default name is the same as input" << endl;
     cout << "  -b           Assembles the code as a BIOS" << endl;
-    cout << "  -g           Outputs an additional file with debug info" << endl;
-    cout << "  --cartoffset Used with '-g': full cart offsets in bytes" << endl;
-    cout << "  --vbinoffset Used with '-g': VBIN section offsets in bytes" << endl;
     cout << "  -v           Displays additional information (verbose)" << endl;
+    cout << "  -g <ref>     Outputs an additional file with debug info" << endl;
+    cout << "The possible reference modes for -g are the following:" << endl;
+    cout << "  program --> '-g' addresses in words relative to program start" << endl;
+    cout << "  vbin    --> '-g' addresses in bytes relative to VBIN file" << endl;
+    cout << "  v32     --> '-g' addresses in bytes relative to V32 file" << endl;
     cout << "Also, the following options are accepted for compatibility" << endl;
     cout << "but have no effect: -s" << endl;
 }
+
 
 // -----------------------------------------------------------------------------
 
@@ -107,6 +110,7 @@ int main( int NumberOfArguments, char* Arguments[] )
         
         // variables to capture input parameters
         string InputPath, OutputPath;
+        DebugInfoModes DebugReference = DebugInfoModes::Program;
         
         // to treat arguments the same in any OS we
         // will convert them to UTF-8 in all cases
@@ -157,24 +161,25 @@ int main( int NumberOfArguments, char* Arguments[] )
             if( ArgumentsUTF8[i] == string("-g") )
             {
                 CreateDebugVersion = true;
-                continue;
-            }
-            
-            if( ArgumentsUTF8[i] == string("--cartoffset") )
-            {
-                CartridgeOffset = true;
-                continue;
-            }
-            
-            if( ArgumentsUTF8[i] == string("--vbinoffset") )
-            {
-                VBINOffset = true;
-                continue;
-            }
-            
-            if( ArgumentsUTF8[i] == string("--debugmode") )
-            {
-                DebugMode = true;
+                
+                // expect another argument
+                i++;
+                
+                if( i >= NumberOfArguments )
+                  throw runtime_error( "missing reference mode after '-g'" );
+                
+                // now we can safely read the debug reference mode
+                string DebugMode = ArgumentsUTF8[ i ];
+                
+                if( DebugMode == "program" )
+                  DebugReference = DebugInfoModes::Program;
+                else if( DebugMode == "vbin" )
+                  DebugReference = DebugInfoModes::VBINFile;
+                else if( DebugMode == "v32" )
+                  DebugReference = DebugInfoModes::V32File;
+                else
+                  throw runtime_error( "unrecognized reference mode after '-g'" );
+                
                 continue;
             }
             
@@ -329,7 +334,7 @@ int main( int NumberOfArguments, char* Arguments[] )
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         // on debug assembly output an additional debug info file
         if( CreateDebugVersion )
-          SaveDebugInfoFile( OutputPath + ".debug", Parser, Emitter );
+          SaveDebugInfoFile( OutputPath + ".debug", Parser, Emitter, DebugReference );
     }
     
     catch( const exception& e )


### PR DESCRIPTION
Added supplemental command-line arguments to the Vircon32 Assembler

* `--cartoffset`
* `--vbinoffset`

For use with the existing `-g` functionality, to convert to bytes and report based on cartridge or VBIN section offsets (for use when analyzing assembler output outside of Vircon32, such as doing a hex dump on a .v32 file or a .vbin file).