### PR TITLE
Emulator performance degradation while window is unfocused

### DIFF
--- a/DesktopEmulator/Emulator/Main.cpp
+++ b/DesktopEmulator/Emulator/Main.cpp
@@ -311,7 +311,10 @@ int main( int NumberOfArguments, char* Arguments[] )
         GlobalLoopActive = true;
         bool WindowActive = true;
         float PendingFrames = 1;
-		int (*SDL_ProcessEvent)(SDL_Event *) = &SDL_PollEvent;
+        
+        // depending on focus changes we will wait for events or
+        // just poll them and continue; this pointer controls that
+        int (*EventProcessor)(SDL_Event *) = &SDL_PollEvent;
         
         // timing control
         StopWatch Watch;
@@ -322,7 +325,7 @@ int main( int NumberOfArguments, char* Arguments[] )
             // process window events
             SDL_Event Event;
             
-            while( SDL_ProcessEvent( &Event ) )
+            while( EventProcessor( &Event ) )
             {
                 // - - - - - - - - - - - - - - - - - - - - - - -
                 // FIRST, PROCESS THE GLOBAL BEHAVIORS
@@ -349,7 +352,7 @@ int main( int NumberOfArguments, char* Arguments[] )
                         LOG("Focus lost");
                         WindowActive = false;
                         MouseIsOnWindow = false;
-						SDL_ProcessEvent = &SDL_WaitEvent;
+                        EventProcessor = &SDL_WaitEvent;
                         Emulator.Pause();
                     }
                     
@@ -360,7 +363,7 @@ int main( int NumberOfArguments, char* Arguments[] )
                     {
                         LOG("Focus gained");
                         WindowActive = true;
-						SDL_ProcessEvent = &SDL_PollEvent;
+                        EventProcessor = &SDL_PollEvent;
                         Emulator.Resume();
                     }
                     

--- a/DesktopEmulator/Emulator/Main.cpp
+++ b/DesktopEmulator/Emulator/Main.cpp
@@ -311,6 +311,7 @@ int main( int NumberOfArguments, char* Arguments[] )
         GlobalLoopActive = true;
         bool WindowActive = true;
         float PendingFrames = 1;
+		int (*SDL_ProcessEvent)(SDL_Event *) = &SDL_PollEvent;
         
         // timing control
         StopWatch Watch;
@@ -321,7 +322,7 @@ int main( int NumberOfArguments, char* Arguments[] )
             // process window events
             SDL_Event Event;
             
-            while( SDL_PollEvent( &Event ) )
+            while( SDL_ProcessEvent( &Event ) )
             {
                 // - - - - - - - - - - - - - - - - - - - - - - -
                 // FIRST, PROCESS THE GLOBAL BEHAVIORS
@@ -348,6 +349,7 @@ int main( int NumberOfArguments, char* Arguments[] )
                         LOG("Focus lost");
                         WindowActive = false;
                         MouseIsOnWindow = false;
+						SDL_ProcessEvent = &SDL_WaitEvent;
                         Emulator.Pause();
                     }
                     
@@ -358,6 +360,7 @@ int main( int NumberOfArguments, char* Arguments[] )
                     {
                         LOG("Focus gained");
                         WindowActive = true;
+						SDL_ProcessEvent = &SDL_PollEvent;
                         Emulator.Resume();
                     }
                     


### PR DESCRIPTION
@t0mmyka from my Computer Organization class noticed, investigated, and found this solution to the issue.

When the emulator window is not in focus, there seems to be a performance degradation with the use of `SDL_PollEvent()`.

This commit instead introduces a function pointer `SDL_ProcessEvent()` which will point at:

* `SDL_PollEvent()` when the window focus is active
* `SDL_WaitEvent()` when the window focus is inactive

