### PR TITLE
Few emulator linux fixes 

### DIFF
--- a/DesktopEmulator/CMakeLists.txt
+++ b/DesktopEmulator/CMakeLists.txt
@@ -52,6 +52,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(TARGET_OS "linux")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(TARGET_OS "mac")
+
 endif()
 
 # -----------------------------------------------------
@@ -379,12 +380,47 @@ endif()
 
 # Extra steps to configure the application on Linux
 if(TARGET_OS STREQUAL "linux")
+
+# -----------------------------------------------------
+#   SET UP CPACK
+# -----------------------------------------------------
+
+    # Force it to be installed in /usr/local
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
+
+    set(CPACK_INSTALL_PREFIX "/usr/local")
+
+    # set up packages
+    set(CPACK_PACKAGE_NAME "vircon32")
+    set(CPACK_PACKAGE_VERSION "1.0.0")
+    set(CPACK_PACKAGE_VENDOR "Palta")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Official emulator for the Vircon32 console")
+    set(CPACK_PACKAGE_CONTACT "@._palta")
+
+    # Set dependencies and package specific configuration
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "@._palta")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+
+    
+    set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+    set(CPACK_RPM_PACKAGE_AUTOPROV ON)
+    set(CPACK_RPM_PACKAGE_NAME "vircon32")
+    set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+    set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
+
+
+    set(CPACK_GENERATOR "DEB;RPM;TGZ")
+
     # Install desktop entry
     install(FILES Resources/Linux/Vircon32.desktop DESTINATION /usr/share/applications )
 
     # Install icon
     install(FILES Resources/Linux/Vircon32.svg DESTINATION /usr/share/pixmaps )
     install(FILES Resources/Linux/Vircon32.svg DESTINATION /usr/share/icons/hicolor/scalable/apps/ )
+
+    include(CPack)
+
 endif()
     
 # On Linux or Mac we will need to set install permissions
@@ -401,3 +437,5 @@ if(TARGET_OS STREQUAL "linux" OR TARGET_OS STREQUAL "mac")
     install(CODE "execute_process(COMMAND chmod 777 ${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/Emulator/Savestates)")
     install(CODE "execute_process(COMMAND chmod 777 ${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/Emulator/Screenshots)")
 endif()
+
+

--- a/DesktopEmulator/CMakeLists.txt
+++ b/DesktopEmulator/CMakeLists.txt
@@ -27,8 +27,8 @@ project("Vircon32" LANGUAGES C CXX)
 
 # Define version
 set(PROJECT_VERSION_MAJOR 25)
-set(PROJECT_VERSION_MINOR 10)
-set(PROJECT_VERSION_PATCH 29)
+set(PROJECT_VERSION_MINOR 12)
+set(PROJECT_VERSION_PATCH 28)
 
 # Set names for final executables
 set(EMULATOR_BINARY_NAME "Vircon32")
@@ -380,49 +380,14 @@ endif()
 
 # Extra steps to configure the application on Linux
 if(TARGET_OS STREQUAL "linux")
-
-# -----------------------------------------------------
-#   SET UP CPACK
-# -----------------------------------------------------
-
-    # Force it to be installed in /usr/local
-    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
-
-    set(CPACK_INSTALL_PREFIX "/usr/local")
-
-    # set up packages
-    set(CPACK_PACKAGE_NAME "vircon32")
-    set(CPACK_PACKAGE_VERSION "1.0.0")
-    set(CPACK_PACKAGE_VENDOR "Palta")
-    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Official emulator for the Vircon32 console")
-    set(CPACK_PACKAGE_CONTACT "@._palta")
-
-    # Set dependencies and package specific configuration
-    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "@._palta")
-    set(CPACK_DEBIAN_PACKAGE_SECTION "games")
-
-    
-    set(CPACK_RPM_PACKAGE_AUTOREQ ON)
-    set(CPACK_RPM_PACKAGE_AUTOPROV ON)
-    set(CPACK_RPM_PACKAGE_NAME "vircon32")
-    set(CPACK_RPM_PACKAGE_LICENSE "MIT")
-    set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
-
-
-    set(CPACK_GENERATOR "DEB;RPM;TGZ")
-
     # Install desktop entry
     install(FILES Resources/Linux/Vircon32.desktop DESTINATION /usr/share/applications )
 
     # Install icon
     install(FILES Resources/Linux/Vircon32.svg DESTINATION /usr/share/pixmaps )
     install(FILES Resources/Linux/Vircon32.svg DESTINATION /usr/share/icons/hicolor/scalable/apps/ )
-
-    include(CPack)
-
 endif()
-    
+
 # On Linux or Mac we will need to set install permissions
 if(TARGET_OS STREQUAL "linux" OR TARGET_OS STREQUAL "mac")
     # Allow emulator to create the debug log
@@ -438,4 +403,40 @@ if(TARGET_OS STREQUAL "linux" OR TARGET_OS STREQUAL "mac")
     install(CODE "execute_process(COMMAND chmod 777 ${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/Emulator/Screenshots)")
 endif()
 
+# -----------------------------------------------------
+#   DEFINE THE PACKAGE CREATION WITH CPACK
+# -----------------------------------------------------
 
+if(TARGET_OS STREQUAL "linux")
+
+    # define install directory
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
+    set(CPACK_INSTALL_PREFIX "/usr/local")
+
+    # define base package info
+    set(CPACK_PACKAGE_NAME "vircon32-emulator")
+    set(CPACK_PACKAGE_VERSION "25.12.28")
+    set(CPACK_PACKAGE_VENDOR "Carra")
+    set(CPACK_PACKAGE_MAINTAINER "Carra")
+    set(CPACK_PACKAGE_LICENSE "BSD-3-Clause")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Desktop emulator for Vircon32 console")
+    set(CPACK_PACKAGE_DESCRIPTION "This is the official Vircon32 desktop emulator for the Debian Linux family. Vircon32 is an open source, 32-bit virtual game console")
+    set(CPACK_PACKAGE_HOMEPAGE_URL "https://www.vircon32.com")
+    
+    # Set dependencies and package specific configuration
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Carra")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+
+    set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+    set(CPACK_RPM_PACKAGE_AUTOPROV ON)
+    set(CPACK_RPM_PACKAGE_NAME "vircon32-emulator")
+    set(CPACK_RPM_PACKAGE_LICENSE "BSD-3-Clause")
+    set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
+
+    set(CPACK_GENERATOR "DEB;RPM;TGZ")
+
+    # finally this reads all CPack variables
+    include(CPack)
+
+endif()

--- a/DesktopEmulator/Resources/Linux/Vircon32.desktop
+++ b/DesktopEmulator/Resources/Linux/Vircon32.desktop
@@ -2,10 +2,10 @@
 Version=22.6.4
 Name=Vircon32
 Comment=Vircon32, a 32-bit virtual game console
-TryExec=/opt/Vircon32/Emulator/Vircon32
-Exec=/opt/Vircon32/Emulator/Vircon32
+TryExec=/usr/local/Vircon32/Emulator/Vircon32
+Exec=/usr/local/Vircon32/Emulator/Vircon32
 Icon=Vircon32
 Terminal=false
 Type=Application
-Categories=games
-Keywords=games;emulation
+Categories=Game;Emulator;
+Keywords=V32;emulator;

--- a/DevelopmentTools/CMakeLists.txt
+++ b/DevelopmentTools/CMakeLists.txt
@@ -69,8 +69,8 @@ project("Vircon32")
 
 # Define version
 set(PROJECT_VERSION_MAJOR 25)
-set(PROJECT_VERSION_MINOR 10)
-set(PROJECT_VERSION_PATCH 29)
+set(PROJECT_VERSION_MINOR 12)
+set(PROJECT_VERSION_PATCH 28)
 
 # Set names for final executables
 set(C_COMPILER_BINARY_NAME "compile")
@@ -526,4 +526,42 @@ endif()
 if(TARGET_OS STREQUAL "linux" OR TARGET_OS STREQUAL "mac")
     # Allow compiler and assembler to create logs
     install(CODE "execute_process(COMMAND chmod 777 ${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/DevTools)")
+endif()
+
+# -----------------------------------------------------
+#   DEFINE THE PACKAGE CREATION WITH CPACK
+# -----------------------------------------------------
+
+if(TARGET_OS STREQUAL "linux")
+
+    # define install directory
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
+    set(CPACK_INSTALL_PREFIX "/usr/local")
+
+    # define base package info
+    set(CPACK_PACKAGE_NAME "vircon32-devtools")
+    set(CPACK_PACKAGE_VERSION "25.12.28")
+    set(CPACK_PACKAGE_VENDOR "Carra")
+    set(CPACK_PACKAGE_MAINTAINER "Carra")
+    set(CPACK_PACKAGE_LICENSE "BSD-3-Clause")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Development tools for Vircon32 console")
+    set(CPACK_PACKAGE_DESCRIPTION "These are the official development tools for Vircon32, for the Debian Linux family. Vircon32 is an open source, 32-bit virtual game console")
+    set(CPACK_PACKAGE_HOMEPAGE_URL "https://www.vircon32.com")
+
+    # Set dependencies and package specific configuration
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Carra")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+
+    set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+    set(CPACK_RPM_PACKAGE_AUTOPROV ON)
+    set(CPACK_RPM_PACKAGE_NAME "vircon32-devtools")
+    set(CPACK_RPM_PACKAGE_LICENSE "BSD-3-Clause")
+    set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
+
+    set(CPACK_GENERATOR "DEB;RPM;TGZ")
+    
+    # finally this reads all CPack variables
+    include(CPack)
+
 endif()


### PR DESCRIPTION
I just wanted to make building packages (deb and rpm) for linux a bit easier/faster, there's no need to manually build them when CPack can do it automatically!
Also, i took the chance to fix the desktop entry that had a wrong category, resulting in the desktop entry to be anywhere except the Games tab on start menus and app launchers.