### PR TITLE
Add support for function pointers to the C compiler

### DIFF
--- a/DevelopmentTools/CCompiler/CNodes.cpp
+++ b/DevelopmentTools/CCompiler/CNodes.cpp
@@ -90,6 +90,7 @@ string NodeTypeToLabel( CNodeTypes Type )
         case CNodeTypes::AssemblyBlock:         return "assembly_block";
         case CNodeTypes::ExpressionAtom:        return "expression_atom";
         case CNodeTypes::FunctionCall:          return "function_call";
+        case CNodeTypes::IndirectCall:          return "indirect_call";
         case CNodeTypes::ArrayAccess:           return "array_access";
         case CNodeTypes::UnaryOperation:        return "unary_operation";
         case CNodeTypes::BinaryOperation:       return "binary_operation";
@@ -1774,6 +1775,7 @@ ExpressionAtomNode::ExpressionAtomNode( CNode* Parent_ )
 {
     ResolvedVariable = nullptr;
     ResolvedEnumValue = nullptr;
+    ResolvedFunction = nullptr;
 }
 
 // -----------------------------------------------------------------------------
@@ -1791,6 +1793,7 @@ string ExpressionAtomNode::ToXML()
     
     return IdentifierName;
 }
+
 
 // -----------------------------------------------------------------------------
 
@@ -1820,6 +1823,14 @@ void ExpressionAtomNode::ResolveIdentifier()
     {
         AtomType = AtomTypes::EnumValue;
         ResolvedEnumValue = (EnumValueNode*)Declaration;
+        return;
+    }
+    
+    // is it a function name used as a value (for function pointers)?
+    else if( Declaration->Type() == CNodeTypes::Function )
+    {
+        AtomType = AtomTypes::Function;
+        ResolvedFunction = (FunctionNode*)Declaration;
         return;
     }
     
@@ -1866,6 +1877,22 @@ void ExpressionAtomNode::DetermineReturnedType()
             return;
         }
         
+        case AtomTypes::Function:
+        {
+            if( !ResolvedFunction )
+              RaiseFatalError( Location, "to get a function type, it needs to be resolved" );
+            
+            // build a FunctionType from the resolved function's prototype
+            list< DataType* > ParamTypes;
+            
+            for( VariableNode* Arg: ResolvedFunction->Arguments )
+              ParamTypes.push_back( Arg->DeclaredType );
+            
+            FunctionType FnType( ResolvedFunction->ReturnType, ParamTypes );
+            ReturnedType = FnType.Clone();
+            return;
+        }
+        
         default:
             RaiseFatalError( Location, "invalid expression atom type" );
     }
@@ -1875,7 +1902,7 @@ void ExpressionAtomNode::DetermineReturnedType()
 
 bool ExpressionAtomNode::IsStatic()
 {
-    return (AtomType != AtomTypes::Variable);
+    return (AtomType != AtomTypes::Variable && AtomType != AtomTypes::Function);
 }
 
 // -----------------------------------------------------------------------------
@@ -2019,8 +2046,8 @@ void FunctionCallNode::DetermineReturnedType()
     if( ReturnedType ) return;
     
     // first, recursively determine all children
-    for( ExpressionNode* Parameter: Parameters )
-      Parameter->DetermineReturnedType();
+    for( ExpressionNode* P: Parameters )
+      P->DetermineReturnedType();
     
     // now go to the referenced function
     if( !ResolvedFunction )
@@ -2115,7 +2142,7 @@ void FunctionCallNode::AllocateCallSpace()
     // find the needed size for this call
     int SizeForThisCall = ResolvedFunction->Arguments.size();
     
-    // find its parent function, if any
+    // find parent stack frame
     CNode* CurrentParent = Parent;
     
     while( CurrentParent )
@@ -2146,9 +2173,210 @@ void FunctionCallNode::AllocateCallSpace()
         
         CurrentParent = CurrentParent->Parent;
     }
+}
+
+
+// =============================================================================
+//      INDIRECT CALL NODE
+// =============================================================================
+
+
+IndirectCallNode::IndirectCallNode( CNode* Parent_ )
+// - - - - - - - - - - - - - - - - - -
+:   ExpressionNode( Parent_ )
+// - - - - - - - - - - - - - - - - - -
+{
+    CalleeExpression = nullptr;
+}
+
+// -----------------------------------------------------------------------------
+
+IndirectCallNode::~IndirectCallNode()
+{
+    delete CalleeExpression;
     
-    // for calls made in the global scope, do nothing
-    // (the emitter will allocate them)
+    for( auto P: Parameters )
+      delete P;
+}
+
+// -----------------------------------------------------------------------------
+
+string IndirectCallNode::ToXML()
+{
+    string Result = "<indirect-call>";
+    Result += XMLBlock( "callee", CalleeExpression->ToXML() );
+    
+    for( ExpressionNode* P: Parameters )
+      Result += XMLBlock( "parameter", P->ToXML() );
+    
+    return Result + "</indirect-call>";
+}
+
+// -----------------------------------------------------------------------------
+
+void IndirectCallNode::DetermineReturnedType()
+{
+    // don't create types twice
+    if( ReturnedType ) return;
+    
+    // first, recursively determine all children
+    CalleeExpression->DetermineReturnedType();
+    
+    for( ExpressionNode* P: Parameters )
+      P->DetermineReturnedType();
+    
+    // callee must be a function pointer, or a bare function type
+    // produced by dereferencing a function pointer: (*fp)()
+    DataType* CalleeType = CalleeExpression->ReturnedType;
+    FunctionType* Prototype = nullptr;
+    
+    if( TypeIsFunctionPointer( CalleeType ) )
+        Prototype = (FunctionType*)((PointerType*)CalleeType)->BaseType;
+    
+    else if( CalleeType->Type() == DataTypes::Function )
+        Prototype = (FunctionType*)CalleeType;
+    
+    else
+      RaiseFatalError( Location, "indirect call callee must be a function pointer" );
+    
+    ReturnedType = Prototype->ReturnType->Clone();
+}
+
+// -----------------------------------------------------------------------------
+
+bool IndirectCallNode::IsStatic()
+{
+    // functions always have to be called
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+
+StaticValue IndirectCallNode::GetStaticValue()
+{
+    RaiseFatalError( Location, "cannot get the static value of a non-static expression" );
+}
+
+// -----------------------------------------------------------------------------
+
+bool IndirectCallNode::HasSideEffects()
+{
+    // all function calls must be executed,
+    // even if they have no actual side effects
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool IndirectCallNode::HasMemoryPlacement()
+{
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+
+bool IndirectCallNode::HasStaticPlacement()
+{
+    // even if a function produces a pointer type, it is
+    // still a dynamic value (it cannot return references)
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+
+MemoryPlacement IndirectCallNode::GetStaticPlacement()
+{
+    RaiseFatalError( Location, "indirect call has no static memory placement" );
+}
+
+// -----------------------------------------------------------------------------
+
+bool IndirectCallNode::UsesFunctionCalls()
+{
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
+int IndirectCallNode::SizeOfNeededTemporaries()
+{
+    int NeededSize = 0;
+    int NestedCallsMaxNeededSize = 0;
+    
+    for( ExpressionNode* P: Parameters )
+    {
+        // every call as a parameter needs 1 temporary
+        if( P->UsesFunctionCalls() )
+          NeededSize += 1;
+        
+        // this parameter call may need temporaries as well
+        int NestedCallNeededSize = P->SizeOfNeededTemporaries();
+        
+        if( NestedCallsMaxNeededSize < NestedCallNeededSize )
+          NestedCallsMaxNeededSize = NestedCallNeededSize;
+    }
+    
+    // calls are made sequentially, so the needed
+    // temporaries are only the largest of these
+    int CallNeededSize = max( NeededSize, NestedCallsMaxNeededSize );
+    
+    // we might also need temporaries to evaluate the callee
+    int CalleeNeededSize = CalleeExpression->SizeOfNeededTemporaries();
+    
+    // we first evaluate callee, then make the call, so
+    // needed temporaries are just the largest of the 2
+    return max( CallNeededSize, CalleeNeededSize );
+}
+
+// -----------------------------------------------------------------------------
+
+void IndirectCallNode::AllocateCallSpace()
+{
+    // access the callee function signature
+    // (callee may be a pointer-to-function or a bare function type from *fp)
+    DataType* CalleeType = CalleeExpression->ReturnedType;
+    FunctionType* Prototype = nullptr;
+    
+    if( TypeIsFunctionPointer( CalleeType ) )
+      Prototype = (FunctionType*)((PointerType*)CalleeType)->BaseType;
+    
+    else
+      Prototype = (FunctionType*)CalleeType;
+    
+    // find the needed size for this call
+    int SizeForThisCall = (int)Prototype->ParameterTypes.size();
+    
+    // find parent stack frame
+    CNode* CurrentParent = Parent;
+    
+    while( CurrentParent )
+    {
+        // CASE 1: call in function stack
+        if( CurrentParent->Type() == CNodeTypes::Function )
+        {
+            FunctionNode* FunctionContext = (FunctionNode*)CurrentParent;
+            
+            // allocate function call
+            if( FunctionContext->StackSizeForFunctionCalls < SizeForThisCall )
+              FunctionContext->StackSizeForFunctionCalls = SizeForThisCall;
+            
+            return;
+        }
+        
+        // CASE 2: call in top-level stack
+        if( CurrentParent->Type() == CNodeTypes::TopLevel )
+        {
+            TopLevelNode* TopLevel = (TopLevelNode*)CurrentParent;
+            
+            // allocate function call
+            if( TopLevel->StackSizeForFunctionCalls < SizeForThisCall )
+              TopLevel->StackSizeForFunctionCalls = SizeForThisCall;
+            
+            return;
+        }
+        
+        CurrentParent = CurrentParent->Parent;
+    }
 }
 
 

--- a/DevelopmentTools/CCompiler/CNodes.hpp
+++ b/DevelopmentTools/CCompiler/CNodes.hpp
@@ -64,6 +64,7 @@ enum class CNodeTypes
     // expressions
     ExpressionAtom,
     FunctionCall,
+    IndirectCall,
     ArrayAccess,
     UnaryOperation,
     BinaryOperation,
@@ -83,7 +84,8 @@ enum class AtomTypes
     LiteralFloat,
     LiteralBoolean,
     EnumValue,
-    Variable
+    Variable,
+    Function
 };
 
 // -----------------------------------------------------------------------------
@@ -1097,6 +1099,7 @@ class ExpressionAtomNode: public ExpressionNode
         // external references
         EnumValueNode* ResolvedEnumValue;
         VariableNode* ResolvedVariable;
+        FunctionNode* ResolvedFunction;
         
     public:
         
@@ -1155,6 +1158,45 @@ class FunctionCallNode: public ExpressionNode
         
         // resolve external references
         void ResolveFunction();
+        
+        // resulting value
+        virtual bool IsStatic();
+        virtual StaticValue GetStaticValue();
+        virtual void DetermineReturnedType();
+        virtual bool HasSideEffects();
+        
+        // resulting memory address
+        virtual bool HasMemoryPlacement();
+        virtual bool HasStaticPlacement();
+        virtual MemoryPlacement GetStaticPlacement();
+        
+        // resource allocation
+        virtual bool UsesFunctionCalls();
+        virtual int SizeOfNeededTemporaries();
+        void AllocateCallSpace();
+};
+
+// -----------------------------------------------------------------------------
+
+class IndirectCallNode: public ExpressionNode
+{
+    public:
+        
+        // node components
+        ExpressionNode* CalleeExpression;
+        std::list< ExpressionNode* > Parameters;
+        
+    public:
+        
+        // instance handling
+        IndirectCallNode( CNode* Parent_ );
+        virtual ~IndirectCallNode();
+        
+        // node classification
+        virtual CNodeTypes Type() { return CNodeTypes::IndirectCall; };
+        
+        // log & debug
+        virtual std::string ToXML();
         
         // resulting value
         virtual bool IsStatic();

--- a/DevelopmentTools/CCompiler/CheckNodes.cpp
+++ b/DevelopmentTools/CCompiler/CheckNodes.cpp
@@ -28,6 +28,9 @@ void CheckExpression( ExpressionNode* Expression )
         case CNodeTypes::FunctionCall:
             CheckFunctionCall( (FunctionCallNode*)Expression );
             return;
+        case CNodeTypes::IndirectCall:
+            CheckIndirectCall( (IndirectCallNode*)Expression );
+            return;
         case CNodeTypes::ArrayAccess:
             CheckArrayAccess( (ArrayAccessNode*)Expression );
             return;
@@ -155,6 +158,16 @@ void CheckExpressionAtom( ExpressionAtomNode* Atom )
       if( !Atom->ResolvedEnumValue )
         RaiseFatalError( Atom->Location, string("enumeration value \"") + Atom->IdentifierName + "\" has not been resolved" );
     
+    // check that any referenced functions have been resolved and fully defined
+    if( Atom->AtomType == AtomTypes::Function )
+    {
+        if( !Atom->ResolvedFunction )
+          RaiseFatalError( Atom->Location, string("function \"") + Atom->IdentifierName + "\" has not been resolved" );
+        
+        if( !Atom->ResolvedFunction->HasBody )
+          RaiseError( Atom->Location, string("function \"") + Atom->IdentifierName + "\" has not been fully defined" );
+    }
+    
     // other atom types are always correct
 }
 
@@ -193,6 +206,60 @@ void CheckFunctionCall( FunctionCallNode* FunctionCall )
     while( ParameterIterator != FunctionCall->Parameters.end() )
     {
         CheckAssignmentTypes( (*ParameterIterator)->Location, (*ArgumentIterator)->DeclaredType, *ParameterIterator );
+        
+        ParameterIterator++;
+        ArgumentIterator++;
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+void CheckIndirectCall( IndirectCallNode* IndirectCall )
+{
+    // first, recursively check the callee expression and all parameters
+    CheckExpression( IndirectCall->CalleeExpression );
+    
+    for( ExpressionNode* Parameter: IndirectCall->Parameters )
+      CheckExpression( Parameter );
+    
+    // to check callee type, we will have 2 valid call syntaxes
+    DataType* CalleeType = IndirectCall->CalleeExpression->ReturnedType;
+    FunctionType* Prototype = nullptr;
+    
+    // option 1: call syntax fp() -> callee is a function pointer
+    if( TypeIsFunctionPointer( CalleeType ) )
+      Prototype = (FunctionType*)((PointerType*)CalleeType)->BaseType;
+    
+    // option 2: call syntax (*fp)() -> callee has function type
+    else if( CalleeType->Type() == DataTypes::Function )
+      Prototype = (FunctionType*)CalleeType;
+    
+    else
+    {
+        RaiseError( IndirectCall->Location, "indirect call requires a function pointer as callee, got " + CalleeType->ToString() );
+        return;
+    }
+    
+    // check number of parameters
+    int ExpectedParameters = Prototype->ParameterTypes.size();
+    int ReceivedParameters = IndirectCall->Parameters.size();
+    
+    if( ReceivedParameters != ExpectedParameters )
+    {
+        string Message = "function pointer expects " + to_string( ExpectedParameters );
+        Message += " parameters, " + to_string( ReceivedParameters ) + " were received";
+        
+        RaiseError( IndirectCall->Location, Message );
+        return;
+    }
+    
+    // check type compatibility for each parameter
+    auto ParameterIterator = IndirectCall->Parameters.begin();
+    auto ArgumentIterator = Prototype->ParameterTypes.begin();
+    
+    while( ParameterIterator != IndirectCall->Parameters.end() )
+    {
+        CheckAssignmentTypes( (*ParameterIterator)->Location, *ArgumentIterator, *ParameterIterator );
         
         ParameterIterator++;
         ArgumentIterator++;

--- a/DevelopmentTools/CCompiler/CheckNodes.cpp
+++ b/DevelopmentTools/CCompiler/CheckNodes.cpp
@@ -158,14 +158,15 @@ void CheckExpressionAtom( ExpressionAtomNode* Atom )
       if( !Atom->ResolvedEnumValue )
         RaiseFatalError( Atom->Location, string("enumeration value \"") + Atom->IdentifierName + "\" has not been resolved" );
     
-    // check that any referenced functions have been resolved and fully defined
+    // check that any referenced functions have been resolved
     if( Atom->AtomType == AtomTypes::Function )
     {
         if( !Atom->ResolvedFunction )
           RaiseFatalError( Atom->Location, string("function \"") + Atom->IdentifierName + "\" has not been resolved" );
         
+        // update the resolved function if it was not fully declared on parse
         if( !Atom->ResolvedFunction->HasBody )
-          RaiseError( Atom->Location, string("function \"") + Atom->IdentifierName + "\" has not been fully defined" );
+          Atom->ResolveIdentifier();
     }
     
     // other atom types are always correct

--- a/DevelopmentTools/CCompiler/CheckNodes.hpp
+++ b/DevelopmentTools/CCompiler/CheckNodes.hpp
@@ -24,6 +24,7 @@ void CheckAssignmentTypes( SourceLocation Location, DataType* LeftType, Expressi
 
 void CheckExpressionAtom( ExpressionAtomNode* Atom );
 void CheckFunctionCall( FunctionCallNode* FunctionCall );
+void CheckIndirectCall( IndirectCallNode* IndirectCall );
 void CheckArrayAccess( ArrayAccessNode* ArrayAccess );
 void CheckUnaryOperation( UnaryOperationNode* Operation );
 void CheckBinaryOperation( BinaryOperationNode* Operation );

--- a/DevelopmentTools/CCompiler/CheckUnaryOperations.cpp
+++ b/DevelopmentTools/CCompiler/CheckUnaryOperations.cpp
@@ -92,7 +92,12 @@ void CheckBitwiseNot( UnaryOperationNode* Operation )
 
 void CheckReference( UnaryOperationNode* Operation )
 {
-    // reference can only operate with memory
+    // special case: taking the address of a named function is always valid
+    if( Operation->Operand->Type() == CNodeTypes::ExpressionAtom )
+      if( ((ExpressionAtomNode*)Operation->Operand)->AtomType == AtomTypes::Function )
+        return;
+    
+    // for everything else, reference can only operate with memory
     if( !Operation->Operand->HasMemoryPlacement() )
       RaiseError( Operation->Location, "reference can only be applied to a memory address" );
 }
@@ -107,13 +112,19 @@ void CheckDereference( UnaryOperationNode* Operation )
     if( OperandType->Type() != DataTypes::Pointer )
       RaiseError( Operation->Location, "dereference can only be applied to a pointer" );
       
-    // void* pointers cannot be dereferenced
-    // (since that would produce a void value)
     else
     {
         PointerType* OperandPointerType = (PointerType*)OperandType;
         
+        // void* pointers cannot be dereferenced
+        // (since that would produce a void value)
         if( OperandPointerType->BaseType->Type() == DataTypes::Void )
           RaiseError( Operation->Location, "pointers to void cannot be dereferenced" );
+        
+        // function pointers can only be dereferenced when used directly
+        // as the callee of an indirect call, with call syntax (*fp)()
+        else if( OperandPointerType->BaseType->Type() == DataTypes::Function )
+          if( !Operation->Parent || Operation->Parent->Type() != CNodeTypes::IndirectCall )
+            RaiseError( Operation->Location, "function pointers can only be dereferenced when calling them" );
     }        
 }

--- a/DevelopmentTools/CCompiler/CheckUnaryOperations.cpp
+++ b/DevelopmentTools/CCompiler/CheckUnaryOperations.cpp
@@ -124,7 +124,22 @@ void CheckDereference( UnaryOperationNode* Operation )
         // function pointers can only be dereferenced when used directly
         // as the callee of an indirect call, with call syntax (*fp)()
         else if( OperandPointerType->BaseType->Type() == DataTypes::Function )
-          if( !Operation->Parent || Operation->Parent->Type() != CNodeTypes::IndirectCall )
+        {
+            CNode* CurrentNode = Operation;
+            
+            while( CurrentNode->Parent && CurrentNode->Parent->IsExpression() )
+            {
+                if( CurrentNode->Parent->Type() == CNodeTypes::IndirectCall )
+                  return;
+                
+                // there could be any number of parenthesis, but nothing else
+                if( CurrentNode->Parent->Type() == CNodeTypes::EnclosedExpression )
+                  CurrentNode = CurrentNode->Parent;
+                
+                else break;
+            }
+            
             RaiseError( Operation->Location, "function pointers can only be dereferenced when calling them" );
+        }
     }        
 }

--- a/DevelopmentTools/CCompiler/DataTypes.cpp
+++ b/DevelopmentTools/CCompiler/DataTypes.cpp
@@ -355,6 +355,54 @@ EnumerationNode* EnumerationType::GetDeclaration( bool MustHaveBody )
 
 
 // =============================================================================
+//      FUNCTION TYPE
+// =============================================================================
+
+
+FunctionType::FunctionType( DataType* ReturnType_, list< DataType* > ParameterTypes_ )
+{
+    ReturnType = ReturnType_->Clone();
+    
+    for( DataType* ParameterType: ParameterTypes_ )
+      ParameterTypes.push_back( ParameterType->Clone() );
+}
+
+// -----------------------------------------------------------------------------
+
+FunctionType::~FunctionType()
+{
+    delete ReturnType;
+    
+    for( DataType* ParameterType: ParameterTypes )
+      delete ParameterType;
+}
+
+// -----------------------------------------------------------------------------
+
+string FunctionType::ToString()
+{
+    string Result = ReturnType->ToString() + "(";
+    bool ListEmpty = true;
+    
+    for( DataType* ParameterType: ParameterTypes )
+    {
+        if( !ListEmpty ) Result += ", ";
+        Result += ParameterType->ToString();
+        ListEmpty = false;
+    }
+    
+    return Result + ")";
+}
+
+// -----------------------------------------------------------------------------
+
+DataType* FunctionType::Clone()
+{
+    return new FunctionType( ReturnType, ParameterTypes );
+}
+
+
+// =============================================================================
 //      DATA TYPE OPERATION
 // =============================================================================
 
@@ -390,6 +438,32 @@ bool AreEqual( DataType* T1, DataType* T2 )
         
         case DataTypes::Enumeration:
             return ((EnumerationType*)T1)->GetDeclaration( false ) == ((EnumerationType*)T2)->GetDeclaration( false );
+        
+        case DataTypes::Function:
+        {
+            FunctionType* F1 = (FunctionType*)T1;
+            FunctionType* F2 = (FunctionType*)T2;
+            
+            if( !AreEqual( F1->ReturnType, F2->ReturnType ) )
+              return false;
+            
+            if( F1->ParameterTypes.size() != F2->ParameterTypes.size() )
+              return false;
+            
+            auto F1Iterator = F1->ParameterTypes.begin();
+            auto F2Iterator = F2->ParameterTypes.begin();
+            
+            while( F1Iterator != F1->ParameterTypes.end() )
+            {
+                if( !AreEqual( *F1Iterator, *F2Iterator ) )
+                  return false;
+                
+                F1Iterator++;
+                F2Iterator++;
+            }
+            
+            return true;
+        }
         
         default:
             throw runtime_error( "invalid data type" );
@@ -437,4 +511,14 @@ bool TypeIsFloat( DataType* T )
       return false;
     
     return ( ((PrimitiveType*)T)->Which == PrimitiveTypes::Float );
+}
+
+// -----------------------------------------------------------------------------
+
+bool TypeIsFunctionPointer( DataType* T )
+{
+    if( T->Type() != DataTypes::Pointer )
+      return false;
+    
+    return ( ((PointerType*)T)->BaseType->Type() == DataTypes::Function );
 }

--- a/DevelopmentTools/CCompiler/DataTypes.hpp
+++ b/DevelopmentTools/CCompiler/DataTypes.hpp
@@ -22,7 +22,8 @@ enum class DataTypes
     Array,
     Structure,
     Union,
-    Enumeration
+    Enumeration,
+    Function
 };
 
 // -----------------------------------------------------------------------------
@@ -247,6 +248,33 @@ class EnumerationType: public DataType
 };
 
 
+// -----------------------------------------------------------------------------
+
+// represents a function signature: return type + parameter types;
+// its size is 0 so that it cannot be evaluated or stored directly
+class FunctionType: public DataType
+{
+    public:
+        
+        DataType* ReturnType;
+        std::list< DataType* > ParameterTypes;
+        
+    public:
+        
+        // instance handling
+        FunctionType( DataType* ReturnType_, std::list< DataType* > ParameterTypes_ );
+        virtual ~FunctionType();
+        
+        // basic properties
+        virtual DataTypes Type() { return DataTypes::Function; }
+        virtual unsigned SizeInWords() { return 0; }
+        virtual std::string ToString();
+        
+        // basic manipulation
+        virtual DataType* Clone();
+};
+
+
 // =============================================================================
 //      DATA TYPE OPERATION
 // =============================================================================
@@ -257,6 +285,7 @@ bool TypeIsThisPrimitive( DataType* T, PrimitiveTypes Primitive );
 bool TypeIsIntegral( DataType* T );
 bool TypeIsNumeric( DataType* T );
 bool TypeIsFloat( DataType* T );
+bool TypeIsFunctionPointer( DataType* T );
 
 
 // *****************************************************************************

--- a/DevelopmentTools/CCompiler/EmitExpressionNodes.cpp
+++ b/DevelopmentTools/CCompiler/EmitExpressionNodes.cpp
@@ -16,11 +16,18 @@
 void VirconCEmitter::EmitExpressionAtom( ExpressionAtomNode* ExpressionAtom, RegisterAllocation& Registers, int ResultRegister )
 {
     // if this function gets called, the atom is not static
-    // (which means it can only be a variable)
-    string ResultRegisterName = "R" + to_string(ResultRegister);
+    // (which means it can only be a variable or a function)
+    
+    // CASE 1: function atoms should never have to be evaluated on their own,
+    // so if we arrive here they were used in an incorrectly formed expression
+    if( ExpressionAtom->AtomType == AtomTypes::Function )
+      RaiseFatalError( ExpressionAtom->Location, "Incorrect use of a function name in an expression" );
+    
+    // CASE 2: variable atoms are emitted with their placement address
     string VariableAddress = ExpressionAtom->ResolvedVariable->Placement.AccessAddressString();
     
     // place the variable value in the register
+    string ResultRegisterName = "R" + to_string(ResultRegister);
     ProgramLines.push_back( "mov " + ResultRegisterName + ", [" + VariableAddress + "]" );
 }
 
@@ -64,10 +71,10 @@ void VirconCEmitter::EmitFunctionCall( FunctionCallNode* FunctionCall, RegisterA
     
     while( ArgumentPositionRev != Function->Arguments.rend() )
     {
-        // discard arguments that do not use calls
         ExpressionNode* Parameter = *ParameterPositionRev;
         VariableNode* Argument = *ArgumentPositionRev;
         
+        // discard arguments that do not use calls
         if( Parameter->UsesFunctionCalls() )
         {
             // emit the evaluation of this parameter
@@ -149,6 +156,151 @@ void VirconCEmitter::EmitFunctionCall( FunctionCallNode* FunctionCall, RegisterA
     
     // release the arguments register
     Registers.RegisterUsed[ ParameterRegister ] = false;
+}
+
+// -----------------------------------------------------------------------------
+
+void VirconCEmitter::EmitIndirectCall( IndirectCallNode* IndirectCall, RegisterAllocation& Registers, int ResultRegister )
+{
+    // obtain the called function prototype; we have 2 possible
+    // syntaxes, so callee may be a function pointer or a bare function
+    DataType* CalleeType = IndirectCall->CalleeExpression->ReturnedType;
+    FunctionType* Prototype = nullptr;
+    
+    if( TypeIsFunctionPointer( CalleeType ) )
+      Prototype = (FunctionType*)((PointerType*)CalleeType)->BaseType;
+  
+    else Prototype = (FunctionType*)CalleeType;
+    
+    // use a single register for all parameters
+    // (but avoid reserving a register if not needed)
+    int ParameterRegister = 0;
+    
+    if( IndirectCall->Parameters.size() > 0 )
+      ParameterRegister = Registers.FirstFreeRegister();
+    
+    string ParameterRegisterName = "R" + to_string( ParameterRegister );
+    
+    // find the stack frame where this call is allocated
+    StackFrameNode* CallingStackFrame = nullptr;
+    CNode* CurrentParent = IndirectCall->Parent;
+    
+    while( CurrentParent )
+    {
+        if( CurrentParent->HasStackFrame() )
+        {
+            CallingStackFrame = (StackFrameNode*)CurrentParent;
+            break;
+        }
+        
+        CurrentParent = CurrentParent->Parent;
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // First pass: precalculate and save any parameters that use
+    // function calls and store them in the stack of temporaries
+    // (since stack is LIFO, use reverse iteration order here)
+    auto ArgumentPositionRev = Prototype->ParameterTypes.rbegin();
+    auto ParameterPositionRev = IndirectCall->Parameters.rbegin();
+    
+    while( ArgumentPositionRev != Prototype->ParameterTypes.rend() )
+    {
+        ExpressionNode* Parameter = *ParameterPositionRev;
+        
+        // discard arguments that do not use calls
+        if( Parameter->UsesFunctionCalls() )
+        {
+            // emit the evaluation of this parameter
+            // (which can now be done independently from this call)
+            EmitDependentExpression( Parameter, Registers, ParameterRegister );
+            
+            // perform type promotion where needed
+            DataType* NeededType  = *ArgumentPositionRev;
+            DataType* ProducedType = Parameter->ReturnedType;
+            EmitRegisterTypeConversion( ParameterRegister, ProducedType, NeededType );
+            
+            // save this value in the stack of temporaries
+            // (careful! stack allocation starts at [BP-1])
+            int FirstTemporaryOffset = CallingStackFrame->StackSizeForVariables + 1;
+            int TemporaryOffsetFromBP = FirstTemporaryOffset + Registers.TemporariesStackSize;
+            string TemporaryAddress = (TemporaryOffsetFromBP == 0 ? "[BP]" : "[BP-" + to_string(TemporaryOffsetFromBP) + "]");
+            ProgramLines.push_back( "mov " + TemporaryAddress + ", " + ParameterRegisterName );
+            
+            // mark the used space for this value in the stack of temporaries
+            Registers.TemporariesStackSize += 1;
+        }
+        
+        ArgumentPositionRev++;
+        ParameterPositionRev++;
+    }
+    
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Second pass: process other arguments, and use the precalculated ones
+    auto ArgumentPosition = Prototype->ParameterTypes.begin();
+    auto ParameterPosition = IndirectCall->Parameters.begin();
+    
+    while( ArgumentPosition != Prototype->ParameterTypes.end() )
+    {
+        ExpressionNode* Parameter = *ParameterPosition;
+        
+        if( Parameter->UsesFunctionCalls() )
+        {
+            // free the used space in the stack of temporaries
+            Registers.TemporariesStackSize -= 1;
+            
+            // load this value from the stack of temporaries
+            // (careful! stack allocation starts at [BP-1])
+            int FirstTemporaryOffset = CallingStackFrame->StackSizeForVariables + 1;
+            int TemporaryOffsetFromBP = FirstTemporaryOffset + Registers.TemporariesStackSize;
+            string TemporaryAddress = (TemporaryOffsetFromBP == 0? "[BP]" : "[BP-" + to_string(TemporaryOffsetFromBP) + "]");
+            ProgramLines.push_back( "mov " + ParameterRegisterName + ", " + TemporaryAddress );
+        }
+        
+        else
+        {
+            // emit the evaluation of this parameter
+            EmitDependentExpression( Parameter, Registers, ParameterRegister );
+            
+            // perform type promotion where needed
+            DataType* NeededType = *ArgumentPosition;
+            DataType* ProducedType = Parameter->ReturnedType;
+            EmitRegisterTypeConversion( ParameterRegister, ProducedType, NeededType );
+        }
+        
+        // place the result as a passed parameter (end of the stack frame);
+        // in direct calls we use argument placement to determine the address
+        // but here we only have types, so we determine it as [SP + index]
+        int ParameterIndex = distance( Prototype->ParameterTypes.begin(), ArgumentPosition );
+        string PassingAddress = (ParameterIndex == 0? "SP" : "SP+" + to_string(ParameterIndex));
+        ProgramLines.push_back( "mov [" + PassingAddress + "], " + ParameterRegisterName );
+        
+        ArgumentPosition++;
+        ParameterPosition++;
+    }
+    
+    // reserve a register for the callee address
+    int CalleeRegister = Registers.FirstFreeRegister();
+    string CalleeRegisterName = "R" + to_string( CalleeRegister );
+    
+    // evaluate the callee expression to get the function address
+    EmitDependentExpression( IndirectCall->CalleeExpression, Registers, CalleeRegister );
+    
+    // emit the indirect call itself
+    ProgramLines.push_back( "call " + CalleeRegisterName );
+    
+    // By calling convention, calls produce their result in R0.
+    // If needed, place the result in the requested register
+    if( ResultRegister != 0 )
+    {
+        string ResultRegisterName = "R" + to_string( ResultRegister );
+        ProgramLines.push_back( "mov " + ResultRegisterName + ", R0" );
+    }
+    
+    // release all used registers
+    Registers.RegisterUsed[ CalleeRegister ] = false;
+    
+    if( IndirectCall->Parameters.size() > 0 )
+      Registers.RegisterUsed[ ParameterRegister ] = false;
 }
 
 // -----------------------------------------------------------------------------

--- a/DevelopmentTools/CCompiler/EmitUnaryOperationNodes.cpp
+++ b/DevelopmentTools/CCompiler/EmitUnaryOperationNodes.cpp
@@ -380,7 +380,16 @@ void VirconCEmitter::EmitDereference( UnaryOperationNode* UnaryOperation, Regist
     // place operand value in result
     EmitDependentExpression( UnaryOperation->Operand, Registers, ResultRegister );
     
-    // obtain value from memory taking previous value as an address
+    // special case: dereferencing a function pointer is actually
+    // just syntactic sugar; indirect calls use the pointer itself,
+    // not the value at that address, so in that case do nothing else
+    DataType* OperandType = UnaryOperation->Operand->ReturnedType;
+    
+    if( OperandType->Type() == DataTypes::Pointer )
+      if( ((PointerType*)OperandType)->BaseType->Type() == DataTypes::Function )
+        return;
+    
+    // for other cases, obtain value from memory taking previous value as an address
     string ResultRegisterName = "R" + to_string(ResultRegister);
     ProgramLines.push_back( "mov " + ResultRegisterName + ", [" + ResultRegisterName + "]" );
 }

--- a/DevelopmentTools/CCompiler/EmitUnaryOperationNodes.cpp
+++ b/DevelopmentTools/CCompiler/EmitUnaryOperationNodes.cpp
@@ -343,8 +343,25 @@ void VirconCEmitter::EmitBitwiseNot( UnaryOperationNode* UnaryOperation, Registe
 
 void VirconCEmitter::EmitReference( UnaryOperationNode* UnaryOperation, RegisterAllocation& Registers, int ResultRegister )
 {
+    // special case: taking the address of a named function emits its label;
+    // we do this here directly instead of calling EmitExpressionAtom because
+    // the only valid use of a function other than being called is being
+    // referenced, so if it is used in some other way it will raise an error    
+    if( UnaryOperation->Operand->Type() == CNodeTypes::ExpressionAtom )
+    {
+        ExpressionAtomNode* Atom = (ExpressionAtomNode*)UnaryOperation->Operand;
+        
+        if( Atom->AtomType == AtomTypes::Function )
+        {
+            string ResultRegisterName = "R" + to_string(ResultRegister);
+            string FunctionLabel = "__function_" + Atom->ResolvedFunction->Name;
+            ProgramLines.push_back( "mov " + ResultRegisterName + ", " + FunctionLabel );
+            return;
+        }
+    }
+    
     // if the operand has side effects, first evaluate it!
-    // if we only take its placement, the sife effects are lost
+    // if we only take its placement, the side effects are lost
     if( UnaryOperation->Operand->HasSideEffects() )
     {
         int TempRegister = Registers.FirstFreeRegister();

--- a/DevelopmentTools/CCompiler/Tests/FunctionPointer.asm
+++ b/DevelopmentTools/CCompiler/Tests/FunctionPointer.asm
@@ -1,0 +1,76 @@
+; program start section
+  call __global_scope_initialization
+  call __function_main
+  hlt
+
+; location of global variables
+  %define global_s1 0
+  %define global_s2 1
+  %define global_s3 2
+
+__global_scope_initialization:
+  push BP
+  mov BP, SP
+  mov SP, BP
+  pop BP
+  ret
+
+__function_add:
+  push BP
+  mov BP, SP
+  push R1
+  mov R0, [BP+2]
+  mov R1, [BP+3]
+  iadd R0, R1
+__function_add_return:
+  pop R1
+  mov SP, BP
+  pop BP
+  ret
+
+__function_main:
+  push BP
+  mov BP, SP
+  isub SP, 3
+  
+  ; int( int, int )* fptr = &add;
+  mov R0, __function_add
+  mov [BP-1], R0
+  
+  ; s1 = add( 10, 20 );
+  mov R2, 10
+  mov [SP], R2
+  mov R2, 20
+  mov [SP+1], R2
+  call __function_add
+  mov R1, R0
+  mov [global_s1], R1
+  mov R0, R1
+  
+  ; s2 = fptr( 30, 40 );
+  mov R2, 30
+  mov [SP], R2
+  mov R2, 40
+  mov [SP+1], R2
+  mov R3, [BP-1]   ; R3 = fptr
+  call R3          ; call fprt
+  mov R1, R0
+  mov [global_s2], R1
+  mov R0, R1
+  
+  ; s3 = (*fptr)( 50, 60 );
+  mov R2, 50
+  mov [SP], R2
+  mov R2, 60
+  mov [SP+1], R2
+  mov R3, [BP-1]   ; R3 = fptr
+  call R3          ; call fptr
+  mov R1, R0
+  mov [global_s3], R1
+  mov R0, R1
+  
+__function_main_return:
+  mov SP, BP
+  pop BP
+  ret
+

--- a/DevelopmentTools/CCompiler/Tests/FunctionPointer.c
+++ b/DevelopmentTools/CCompiler/Tests/FunctionPointer.c
@@ -1,0 +1,14 @@
+int add( int a, int b )
+{
+    return a + b;
+}
+
+int s1, s2, s3;
+
+void main()
+{
+    int( int, int )* fptr = &add;
+    s1 = add( 10, 20 );
+    s2 = fptr( 30, 40 );
+    s3 = (*fptr)( 50, 60 );
+}

--- a/DevelopmentTools/CCompiler/Tests/FunctionPointersArray.asm
+++ b/DevelopmentTools/CCompiler/Tests/FunctionPointersArray.asm
@@ -1,0 +1,71 @@
+; program start section
+  call __global_scope_initialization
+  call __function_main
+  hlt
+
+; location of global variables
+  %define global_operations 0
+  %define global_sum 2
+
+__global_scope_initialization:
+  push BP
+  mov BP, SP
+  
+  ; operations[ 0 ] = &add;
+  mov R0, __function_add
+  mov [global_operations], R0
+  ; operations[ 1 ] = &sub;
+  mov R0, __function_sub
+  mov [1], R0
+  
+  mov SP, BP
+  pop BP
+  ret
+
+__function_main:
+  push BP
+  mov BP, SP
+  isub SP, 2
+  
+  ; sum = operations[ 0 ]( 10, 20 );
+  mov R2, 10
+  mov [SP], R2
+  mov R2, 20
+  mov [SP+1], R2
+  mov R3, [global_operations]
+  call R3
+  mov R1, R0
+  mov [global_sum], R1
+  mov R0, R1
+  
+__function_main_return:
+  mov SP, BP
+  pop BP
+  ret
+
+__function_add:
+  push BP
+  mov BP, SP
+  push R1
+  mov R0, [BP+2]
+  mov R1, [BP+3]
+  iadd R0, R1
+__function_add_return:
+  pop R1
+  mov SP, BP
+  pop BP
+  ret
+
+__function_sub:
+  push BP
+  mov BP, SP
+  push R1
+  mov R0, [BP+2]
+  mov R1, [BP+3]
+  isub R0, R1
+__function_sub_return:
+  pop R1
+  mov SP, BP
+  pop BP
+  ret
+

--- a/DevelopmentTools/CCompiler/Tests/FunctionPointersArray.c
+++ b/DevelopmentTools/CCompiler/Tests/FunctionPointersArray.c
@@ -1,0 +1,20 @@
+int add( int a, int b );
+int sub( int a, int b );
+
+int(int, int)*[ 2 ] operations = { &add, &sub };
+int sum;
+
+void main()
+{
+    sum = operations[ 0 ]( 10, 20 );
+}
+
+int add( int a, int b )
+{
+    return a + b;
+}
+
+int sub( int a, int b )
+{
+    return a - b;
+}

--- a/DevelopmentTools/CCompiler/VirconCEmitter.cpp
+++ b/DevelopmentTools/CCompiler/VirconCEmitter.cpp
@@ -146,8 +146,10 @@ int VirconCEmitter::EmitRootExpression( ExpressionNode* Expression )
     // nothing to do if they are not used
     if( !Expression ) return 0;
     
-    // determine if a register other than R0 should be used
+    // determine if register R0 is used internally; then we
+    // should reserve another register to protect its contents
     bool ProtectR0 = (Expression->Type() != CNodeTypes::FunctionCall)
+                  && (Expression->Type() != CNodeTypes::IndirectCall)
                   && Expression->UsesFunctionCalls();
     
     // now begin evaluation of a new expression tree
@@ -211,6 +213,10 @@ void VirconCEmitter::EmitDependentExpression( ExpressionNode* Expression, Regist
             
         case CNodeTypes::FunctionCall:
             EmitFunctionCall( (FunctionCallNode*)Expression, Registers, ResultRegister );
+            break;
+            
+        case CNodeTypes::IndirectCall:
+            EmitIndirectCall( (IndirectCallNode*)Expression, Registers, ResultRegister );
             break;
             
         case CNodeTypes::ArrayAccess:

--- a/DevelopmentTools/CCompiler/VirconCEmitter.hpp
+++ b/DevelopmentTools/CCompiler/VirconCEmitter.hpp
@@ -74,6 +74,7 @@ class VirconCEmitter
         // (sizeof is not needed: it is always static)
         void EmitExpressionAtom     ( ExpressionAtomNode* ExpressionAtom          , RegisterAllocation& Registers, int ResultRegister );
         void EmitFunctionCall       ( FunctionCallNode* FunctionCall              , RegisterAllocation& Registers, int ResultRegister );
+        void EmitIndirectCall       ( IndirectCallNode* IndirectCall              , RegisterAllocation& Registers, int ResultRegister );
         void EmitArrayAccess        ( ArrayAccessNode* ArrayAccess                , RegisterAllocation& Registers, int ResultRegister );
         void EmitUnaryOperation     ( UnaryOperationNode* UnaryOperation          , RegisterAllocation& Registers, int ResultRegister );
         void EmitBinaryOperation    ( BinaryOperationNode* BinaryOperation        , RegisterAllocation& Registers, int ResultRegister );

--- a/DevelopmentTools/CCompiler/VirconCParser.cpp
+++ b/DevelopmentTools/CCompiler/VirconCParser.cpp
@@ -727,17 +727,22 @@ DataType* VirconCParser::ParseType( CNode* Parent, CTokenIterator& TokenPosition
     
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     
-    // keep reading pointer and array modifiers
+    // now keep reading type modifiers to make pointers, arrays and functions
     while( (*TokenPosition)->Type() != CTokenTypes::EndOfFile )
     {
-        // read a pointer modifier
+        // read a pointer modifier: Type*
         if( TokenIsThisOperator( *TokenPosition, OperatorTypes::Asterisk ) )
         {
+            // consume '*'
             TokenPosition++;
+            
+            // expand base type into a pointer to that type
+            DataType* OldParsedType = ParsedType;
             ParsedType = new PointerType( ParsedType );
+            delete OldParsedType;
         }
         
-        // read an array modifier
+        // read an array modifier: Type[...]
         else if( TokenIsThisDelimiter( *TokenPosition, DelimiterTypes::OpenBracket ) )
         {
             // array indices are read from left to right, not the
@@ -776,7 +781,71 @@ DataType* VirconCParser::ParseType( CNode* Parent, CTokenIterator& TokenPosition
             // now keep building arrays in the usual order
             // (as if they had been found right to left)
             for( int Dimension: Dimensions )
-              ParsedType = new ArrayType( ParsedType, Dimension );
+            {
+                // expand base type into an array of that type
+                DataType* OldParsedType = ParsedType;
+                ParsedType = new ArrayType( ParsedType, Dimension );
+                delete OldParsedType;
+            }
+        }
+        
+        // read a function modifier: Type(...)
+        else if( TokenIsThisDelimiter( *TokenPosition, DelimiterTypes::OpenParenthesis ) )
+        {
+            // validate the return type before continuing
+            if( ParsedType->Type() == DataTypes::Array )
+              RaiseFatalError( (*TokenPosition)->Location, "invalid type: functions cannot return arrays, only pointers to them" );
+            
+            if( ParsedType->Type() == DataTypes::Function )
+              RaiseFatalError( (*TokenPosition)->Location, "invalid type: functions cannot return other functions, only pointers to them" );
+            
+            // consume '('
+            TokenPosition++;
+            
+            list< DataType* > ParameterTypes;
+            
+            // special case: '(void)' means no parameters
+            if( TokenIsThisKeyword( *TokenPosition, KeywordTypes::Void )
+            &&  TokenIsThisDelimiter( *Next(TokenPosition), DelimiterTypes::CloseParenthesis ) )
+            {
+                // consume 'void'
+                TokenPosition++;
+            }
+            
+            // parse regular parameter lists
+            else while( !IsLastToken( *TokenPosition ) )
+            {
+                // detect end of list
+                if( TokenIsThisDelimiter( *TokenPosition, DelimiterTypes::CloseParenthesis ) )
+                  break;
+                
+                // parse next parameter type
+                if( !ParameterTypes.empty() )
+                  ExpectSpecialSymbol( TokenPosition, SpecialSymbolTypes::Comma );
+                
+                DataType* ParsedParameterType = ParseType( Parent, TokenPosition );
+                ParameterTypes.push_back( ParsedParameterType );
+                
+                // validate this parameter type before continuing
+                if( ParsedParameterType->Type() == DataTypes::Array )
+                  RaiseFatalError( (*TokenPosition)->Location, "invalid type: functions cannot take arrays as parameters, only pointers to them" );
+                
+                if( ParsedParameterType->Type() == DataTypes::Function )
+                  RaiseFatalError( (*TokenPosition)->Location, "invalid type: functions cannot take other functions as parameters, only pointers to them" );
+            }
+            
+            // consume ')'
+            ExpectDelimiter( TokenPosition, DelimiterTypes::CloseParenthesis );
+            
+            // expand base type into a function returning that type
+            DataType* OldParsedType = ParsedType;
+            ParsedType = new FunctionType( ParsedType, ParameterTypes );
+            delete OldParsedType;
+            
+            // function type clones all parameter types, so now
+            // delete the parameter types we used to build it
+            for( DataType* PT: ParameterTypes )
+              delete PT;
         }
         
         else break;
@@ -1554,24 +1623,42 @@ ExpressionNode* VirconCParser::ParseExpression( CNode* Parent, CTokenIterator& T
           PrimaryExpression = ParseEnclosedExpression( Parent, TokenPosition );
     }
     
-    // CASE 3: String literals
+    // CASE 4: String literals
     if( NextToken->Type() == CTokenTypes::LiteralString )
       PrimaryExpression = ParseLiteralString( Parent, TokenPosition );
     
-    // CASE 4: Unary operator
+    // CASE 5: Unary operator
     else if( TokenIsUnaryOperator( NextToken ) )
       PrimaryExpression = ParseUnaryOperation( Parent, TokenPosition );
     
-    // CASE 5: Function call
+    // CASE 6: Function calls
     else if( NextToken->Type() == CTokenTypes::Identifier )
     {
         CToken* FollowingToken = *Next( TokenPosition );
         
         if( TokenIsThisDelimiter( FollowingToken, DelimiterTypes::OpenParenthesis ) )
-          PrimaryExpression = ParseFunctionCall( Parent, TokenPosition );
+        {
+            // Determine whether the identifier name is a function or a variable.
+            string SymbolName = ((IdentifierToken*)NextToken)->Name;
+            ScopeNode* Scope = Parent->FindClosestScope( true );
+            CNode* Declaration = Scope->ResolveIdentifier( SymbolName );
+            bool IsFunction = (Declaration && Declaration->Type() == CNodeTypes::Function);
+            
+            // CASE 6-A: Direct function call
+            if( IsFunction )
+              PrimaryExpression = ParseFunctionCall( Parent, TokenPosition );
+            
+            // CASE 6-B: Indirect call through a pointer
+            else
+            {
+                // Parse the identifier as an atom, then parse the argument list
+                ExpressionAtomNode* CalleeAtom = ParseExpressionAtom( Parent, TokenPosition );
+                PrimaryExpression = ParseIndirectCall( Parent, CalleeAtom, TokenPosition );
+            }
+        }
     }
     
-    // CASE 6: Atom (all other cases)
+    // CASE 7: Atom (all other cases)
     if( !PrimaryExpression )
       PrimaryExpression = ParseExpressionAtom( Parent, TokenPosition );
     
@@ -1627,6 +1714,11 @@ ExpressionNode* VirconCParser::ParseExpression( CNode* Parent, CTokenIterator& T
             PrimaryExpression->Parent = UnaryOperation;
             PrimaryExpression = UnaryOperation;
         }
+        
+        // CASE 6: Indirect call via '(' after a non-identifier primary
+        // expression, like (*fn_ptr)(...) or ptr_array[i](...)
+        else if( TokenIsThisDelimiter( NextToken, DelimiterTypes::OpenParenthesis ) )
+          PrimaryExpression = ParseIndirectCall( Parent, PrimaryExpression, TokenPosition );
         
         else break;
     }
@@ -1703,6 +1795,7 @@ ExpressionAtomNode* VirconCParser::ParseExpressionAtom( CNode* Parent, CTokenIte
             Atom->FloatValue = Literal->FloatValue;
             return Atom;
         }
+        
         // 1-C: Literal boolean
         else
         {
@@ -1751,20 +1844,19 @@ FunctionCallNode* VirconCParser::ParseFunctionCall( CNode* Parent, CTokenIterato
     FunctionCall->FunctionName = ExpectIdentifier( TokenPosition );
     TokenPosition++;
     
+    // parse the parameter list
     while( !IsLastToken( *TokenPosition ) )
     {
         CToken* NextToken = *TokenPosition;
         
-        // keep adding parameters until
-        // we find a closing parenthesis
+        // keep adding parameters until we find a closing parenthesis
         if( TokenIsThisDelimiter( NextToken, DelimiterTypes::CloseParenthesis ) )
         {
             TokenPosition++;
             break;
         }
         
-        // if this is not the first parameter,
-        // expect a comma as separation
+        // if this is not the first parameter, expect a comma as separation
         if( !FunctionCall->Parameters.empty() )
           ExpectSpecialSymbol( TokenPosition, SpecialSymbolTypes::Comma );
         
@@ -1779,6 +1871,49 @@ FunctionCallNode* VirconCParser::ParseFunctionCall( CNode* Parent, CTokenIterato
     FunctionCall->AllocateCallSpace();
     
     return FunctionCall;
+}
+
+// -----------------------------------------------------------------------------
+
+IndirectCallNode* VirconCParser::ParseIndirectCall( CNode* Parent, ExpressionNode* Callee, CTokenIterator& TokenPosition )
+{
+    IndirectCallNode* IndirectCall = new IndirectCallNode( Parent );
+    IndirectCall->Location = (*TokenPosition)->Location;
+    
+    // take ownership of the callee expression
+    IndirectCall->CalleeExpression = Callee;
+    Callee->Parent = IndirectCall;
+    
+    // here we already know '(' is next; consume it
+    TokenPosition++;
+    
+    // parse the parameter list
+    while( !IsLastToken( *TokenPosition ) )
+    {
+        CToken* NextToken = *TokenPosition;
+        
+        // keep adding parameters until we find a closing parenthesis
+        if( TokenIsThisDelimiter( NextToken, DelimiterTypes::CloseParenthesis ) )
+        {
+            TokenPosition++;
+            break;
+        }
+        
+        // if this is not the first parameter, expect a comma as separation
+        if( !IndirectCall->Parameters.empty() )
+          ExpectSpecialSymbol( TokenPosition, SpecialSymbolTypes::Comma );
+        
+        // expect an expression as next parameter
+        IndirectCall->Parameters.push_back( ParseExpression( Parent, TokenPosition ) );
+    }
+    
+    // determine types now so AllocateCallSpace can use them
+    IndirectCall->CalleeExpression->DetermineReturnedType();
+    
+    // allocate call space in the containing stack frame
+    IndirectCall->AllocateCallSpace();
+    
+    return IndirectCall;
 }
 
 // -----------------------------------------------------------------------------
@@ -2133,9 +2268,6 @@ void VirconCParser::ParseTopLevel( CTokenList& Tokens_ )
             
             if( IT->Name == "const" )
               RaiseFatalError( NextToken->Location, "const variables are not supported in this compiler" );
-            
-            if( IT->Name == "enum" )
-              RaiseFatalError( NextToken->Location, "enumerations are not supported in this compiler" );
         }
         
         // any other cases are not valid

--- a/DevelopmentTools/CCompiler/VirconCParser.hpp
+++ b/DevelopmentTools/CCompiler/VirconCParser.hpp
@@ -79,6 +79,7 @@ class VirconCParser
         ExpressionNode* ParseExpression( CNode* Parent, CTokenIterator& TokenPosition, bool Greedy = true );
         ExpressionAtomNode* ParseExpressionAtom( CNode* Parent, CTokenIterator& TokenPosition );
         FunctionCallNode* ParseFunctionCall( CNode* Parent, CTokenIterator& TokenPosition );
+        IndirectCallNode* ParseIndirectCall( CNode* Parent, ExpressionNode* Callee, CTokenIterator& TokenPosition );
         ArrayAccessNode* ParseArrayAccess( CNode* Parent, ExpressionNode* ArrayOperand, CTokenIterator& TokenPosition );
         UnaryOperationNode* ParseUnaryOperation( CNode* Parent, CTokenIterator& TokenPosition );
         BinaryOperationNode* ParseBinaryOperation( CNode* Parent, ExpressionNode* LeftOperand, OperatorToken* Operator, CTokenIterator& TokenPosition );


### PR DESCRIPTION
Merging this development branch into main allows the Vircon32 C compiler to work with function pointers. This should not affect compilation of previous programs in any way.